### PR TITLE
chore: add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+      - name: Set up Python
+        run: uv venv --python 3.12
+      - name: Install dev extras
+        run: uv pip install -e ".[dev]"
+      - name: Run pre-commit
+        run: |
+          source .venv/bin/activate
+          pre-commit run --all-files --show-diff-on-failure
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv venv --python ${{ matrix.python-version }}
+      - name: Install dev extras
+        run: uv pip install -e ".[dev]"
+      - name: Import smoke test
+        run: |
+          source .venv/bin/activate
+          python -c "import alphaex.sweeper, alphaex.submitter, numpy; print('ok')"
+      - name: Run sweeper test
+        run: |
+          source .venv/bin/activate
+          python -m test.test_sweeper > /dev/null


### PR DESCRIPTION
Runs on push to master and on pull requests. Two jobs:

- lint: installs dev extras with uv on Python 3.12 and runs `pre-commit run --all-files` with `--show-diff-on-failure`.
- test: matrix over Python 3.9-3.12, installs the project + dev extras with uv, runs an import smoke test, and runs the existing `python -m test.test_sweeper` example.

Pinned to major action tags (`@v4`) so the existing dependabot github-actions group can bump them. `fail-fast: false` so one matrix slot failing doesn't hide the others.