### PR TITLE
feat: add docker mini-slurm sandbox for local end-to-end testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,29 @@ jobs:
         run: |
           source .venv/bin/activate
           pytest --cov=alphaex --cov-report=term-missing
+
+  local-slurm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+      - name: Set up Python
+        run: uv venv --python 3.12
+      - name: Install dev extras
+        run: uv pip install -e ".[dev]"
+      - name: Bring up mini-slurm
+        run: bash docker/setup.sh
+      - name: Run local-slurm integration test
+        env:
+          ALPHAEX_LOCAL_SLURM: "1"
+        run: |
+          source .venv/bin/activate
+          pytest test/test_submitter_local.py -v
+      - name: Show docker logs on failure
+        if: failure()
+        run: docker compose -f docker/docker-compose.yml logs
+      - name: Teardown
+        if: always()
+        run: bash docker/teardown.sh

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,7 @@ test/plot
 .coverage
 .pytest_cache/
 .ruff_cache/
+docker/keys/
+test/output/
+test/error/
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ The above 2 functions are implemented in 2 self-contained python scripts
 Sweeper can be used in any machine with python 3 installed. But submitter is only compatible with **slurm**.
 Make sure you have access to at least one cluster with slurm installed. For example, I
 have an account on compute canada, so I can use clusters including cedar, mp2, etc.
+If you want to try the submitter without an HPC account, see
+[Running Submitter Locally (Mini-Slurm)](#running-submitter-locally-mini-slurm)
+for a Docker-based two-cluster sandbox.
 
 To test these 2 modules, run
 `python test/test_submitter.py`, `python test/test_sweeper.py`
@@ -188,6 +191,35 @@ Since the server needs to keep running a program to monitor job status and submi
 It may not be a good idea to use your own laptop as the server because the laptop may lose internet connection.
 Our suggestion is to use one cluster as the server and use a program like screen to make
 sure that the monitor program runs in the background even if you logout from the server.
+
+### Running Submitter Locally (Mini-Slurm)
+
+For development or evaluation without an HPC account, `docker/` ships a
+two-container Slurm sandbox that the submitter can drive end-to-end over SSH,
+just like a real cluster.
+
+Prerequisites: Docker Desktop (or any Docker engine) with `docker compose`
+available.
+
+```bash
+bash docker/setup.sh                                # build + start, wires ~/.ssh/config
+ALPHAEX_LOCAL_SLURM=1 uv run pytest test/test_submitter_local.py -v
+ls test/output/                                     # submit_1.txt ... submit_4.txt
+bash docker/teardown.sh                             # stop containers + clean ~/.ssh/config
+```
+
+`setup.sh` generates a dedicated ed25519 keypair under `docker/keys/`,
+appends `Host cluster-a` and `Host cluster-b` blocks to your `~/.ssh/config`
+(inside a guarded `# >>> alphaex-slurm` marker so teardown can remove them),
+publishes container SSH on ports 2221 and 2222, and waits for both clusters
+to accept logins. The repo is bind-mounted into each container at
+`/home/alphaex/AlphaEx`, so job output written to `test/output/` from inside
+the cluster lands directly on the host.
+
+This sandbox is meant for development of the submitter itself. It runs one
+node per cluster on a single host, uses a fake `alphaex` account, and has
+no scheduler accounting — it is not a substitute for a real cluster for
+running real experiments.
 
 ## Sweeper
 Using sweeper, you can sweep all the experiment variables using one click. These

--- a/docker/Dockerfile.slurm
+++ b/docker/Dockerfile.slurm
@@ -1,0 +1,25 @@
+FROM debian:bullseye-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        slurm-wlm \
+        munge \
+        openssh-server \
+        python3 \
+        python3-venv \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /var/run/sshd \
+    && ssh-keygen -A \
+    && useradd --create-home --uid 1000 --shell /bin/bash alphaex \
+    && mkdir -p /var/spool/slurmctld /var/spool/slurmd /var/log/slurm \
+    && chown slurm:slurm /var/spool/slurmctld /var/spool/slurmd /var/log/slurm
+
+COPY slurm.conf /etc/slurm/slurm.conf
+COPY cgroup.conf /etc/slurm/cgroup.conf
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+EXPOSE 22
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/cgroup.conf
+++ b/docker/cgroup.conf
@@ -1,0 +1,1 @@
+CgroupAutomount=no

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,27 @@
+services:
+  cluster-a:
+    build:
+      context: .
+      dockerfile: Dockerfile.slurm
+    image: alphaex-slurm
+    hostname: cluster
+    ports:
+      - "2221:22"
+    volumes:
+      - ../:/home/alphaex/AlphaEx:rw
+      - ./keys/authorized_keys:/etc/alphaex_authorized_keys:ro
+    privileged: true
+    cgroup: host
+
+  cluster-b:
+    image: alphaex-slurm
+    hostname: cluster
+    ports:
+      - "2222:22"
+    volumes:
+      - ../:/home/alphaex/AlphaEx:rw
+      - ./keys/authorized_keys:/etc/alphaex_authorized_keys:ro
+    privileged: true
+    cgroup: host
+    depends_on:
+      - cluster-a

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Munge runtime dirs (no systemd-tmpfiles to create these for us).
+install -d -m 0755 -o munge -g munge /run/munge /var/log/munge /var/lib/munge
+
+# Munge key (per-container; the two clusters are independent).
+if [ ! -s /etc/munge/munge.key ]; then
+    dd if=/dev/urandom bs=1 count=1024 of=/etc/munge/munge.key 2>/dev/null
+fi
+chown munge:munge /etc/munge/munge.key
+chmod 0400 /etc/munge/munge.key
+
+# Authorized key for the alphaex user (mounted in read-only from the host).
+mkdir -p /home/alphaex/.ssh
+if [ -f /etc/alphaex_authorized_keys ]; then
+    cp /etc/alphaex_authorized_keys /home/alphaex/.ssh/authorized_keys
+fi
+chmod 700 /home/alphaex/.ssh
+chmod 600 /home/alphaex/.ssh/authorized_keys 2>/dev/null || true
+chown -R alphaex:alphaex /home/alphaex/.ssh
+
+# Slurm daemons.
+runuser -u munge -- /usr/sbin/munged
+runuser -u slurm -- /usr/sbin/slurmctld
+/usr/sbin/slurmd
+
+# sshd in the foreground so it owns PID 1's signal lifecycle.
+exec /usr/sbin/sshd -D -e

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Bootstrap the local mini-Slurm stack: generate a dedicated SSH keypair,
+# inject Host entries into ~/.ssh/config (under a guarded marker block),
+# bring up the two cluster containers, and wait for sshd to accept logins.
+#
+# Idempotent: rerunning is safe.
+set -euo pipefail
+
+DOCKER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$DOCKER_DIR/.." && pwd)"
+KEYS_DIR="$DOCKER_DIR/keys"
+KEY_PATH="$KEYS_DIR/id_alphaex_slurm"
+KNOWN_HOSTS="$KEYS_DIR/known_hosts"
+SSH_CONFIG="$HOME/.ssh/config"
+MARK_START="# >>> alphaex-slurm"
+MARK_END="# <<< alphaex-slurm"
+
+mkdir -p "$KEYS_DIR"
+if [ ! -f "$KEY_PATH" ]; then
+    ssh-keygen -t ed25519 -f "$KEY_PATH" -N "" -q -C alphaex-mini-slurm
+fi
+cp "$KEY_PATH.pub" "$KEYS_DIR/authorized_keys"
+
+mkdir -p "$HOME/.ssh"
+touch "$SSH_CONFIG"
+chmod 600 "$SSH_CONFIG"
+if ! grep -qF "$MARK_START" "$SSH_CONFIG"; then
+    cat >> "$SSH_CONFIG" <<EOF
+
+$MARK_START
+Host cluster-a
+    HostName localhost
+    Port 2221
+    User alphaex
+    IdentityFile $KEY_PATH
+    UserKnownHostsFile $KNOWN_HOSTS
+    StrictHostKeyChecking accept-new
+    IdentitiesOnly yes
+Host cluster-b
+    HostName localhost
+    Port 2222
+    User alphaex
+    IdentityFile $KEY_PATH
+    UserKnownHostsFile $KNOWN_HOSTS
+    StrictHostKeyChecking accept-new
+    IdentitiesOnly yes
+$MARK_END
+EOF
+fi
+
+echo "[setup] building and starting the mini-slurm stack..."
+docker compose -f "$DOCKER_DIR/docker-compose.yml" up -d --build
+
+wait_for_ssh() {
+    local host=$1
+    local i
+    for i in $(seq 1 30); do
+        if ssh -o BatchMode=yes -o ConnectTimeout=2 "$host" true 2>/dev/null; then
+            echo "[setup] $host is ready"
+            return 0
+        fi
+        sleep 1
+    done
+    echo "[setup] $host did not accept ssh within 30s" >&2
+    docker compose -f "$DOCKER_DIR/docker-compose.yml" logs "$host" >&2 || true
+    return 1
+}
+
+wait_for_ssh cluster-a
+wait_for_ssh cluster-b
+
+echo
+echo "Mini-slurm is ready. Try:"
+echo "  ssh cluster-a sinfo"
+echo "  ALPHAEX_LOCAL_SLURM=1 uv run pytest test/test_submitter_local.py -v"
+echo
+echo "Tear down with: bash docker/teardown.sh"

--- a/docker/slurm.conf
+++ b/docker/slurm.conf
@@ -1,0 +1,24 @@
+ClusterName=local
+SlurmctldHost=cluster
+
+SlurmUser=slurm
+SlurmctldPort=6817
+SlurmdPort=6818
+AuthType=auth/munge
+StateSaveLocation=/var/spool/slurmctld
+SlurmdSpoolDir=/var/spool/slurmd
+SlurmctldLogFile=/var/log/slurm/slurmctld.log
+SlurmdLogFile=/var/log/slurm/slurmd.log
+
+SwitchType=switch/none
+MpiDefault=none
+ProctrackType=proctrack/linuxproc
+TaskPlugin=task/none
+JobCompType=jobcomp/none
+ReturnToService=2
+SchedulerType=sched/backfill
+SelectType=select/cons_tres
+SelectTypeParameters=CR_Core
+
+NodeName=cluster State=UNKNOWN
+PartitionName=debug Nodes=cluster Default=YES MaxTime=INFINITE State=UP

--- a/docker/teardown.sh
+++ b/docker/teardown.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Tear down the local mini-Slurm stack: bring containers down (removing
+# anonymous volumes), strip the guarded ~/.ssh/config block, and remove
+# the known_hosts file so a future setup starts clean.
+set -euo pipefail
+
+DOCKER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SSH_CONFIG="$HOME/.ssh/config"
+MARK_START="# >>> alphaex-slurm"
+MARK_END="# <<< alphaex-slurm"
+
+docker compose -f "$DOCKER_DIR/docker-compose.yml" down -v || true
+
+if [ -f "$SSH_CONFIG" ] && grep -qF "$MARK_START" "$SSH_CONFIG"; then
+    # macOS and GNU sed differ; use awk for portability.
+    tmp=$(mktemp)
+    awk -v start="$MARK_START" -v end="$MARK_END" '
+        $0 == start {skip=1; next}
+        $0 == end   {skip=0; next}
+        !skip
+    ' "$SSH_CONFIG" > "$tmp"
+    mv "$tmp" "$SSH_CONFIG"
+    chmod 600 "$SSH_CONFIG"
+fi
+
+rm -f "$DOCKER_DIR/keys/known_hosts"
+
+echo "[teardown] stack stopped and ~/.ssh/config block removed"

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Short-name variant of test/submit.sh used by the local mini-Slurm test.
+# A short basename ("run.sh") survives slurm's default squeue NAME-column
+# width so `_count_active_jobs` substring matching keeps working.
+
+#SBATCH --output=test/output/submit_%a.txt
+#SBATCH --error=test/error/submit_%a.txt
+
+mkdir -p test/output test/error
+export OMP_NUM_THREADS=1
+
+echo "${python_module}" "${SLURM_ARRAY_TASK_ID}" "${config_file}"
+python3 -m "${python_module}" "${SLURM_ARRAY_TASK_ID}" "${config_file}"

--- a/test/test_submitter_local.py
+++ b/test/test_submitter_local.py
@@ -1,0 +1,81 @@
+"""Integration test against the docker mini-Slurm stack.
+
+Skipped unless ``ALPHAEX_LOCAL_SLURM=1`` is set, so the regular
+``pytest`` invocation collects but doesn't try to run it. To enable
+locally:
+
+    bash docker/setup.sh
+    ALPHAEX_LOCAL_SLURM=1 uv run pytest test/test_submitter_local.py -v
+"""
+
+import os
+import shutil
+import time
+from pathlib import Path
+
+import pytest
+
+from alphaex.submitter import Submitter
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("ALPHAEX_LOCAL_SLURM") != "1",
+    reason="requires the docker mini-slurm stack (see docker/setup.sh)",
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PROJECT_ROOT_DIR = "/home/alphaex/AlphaEx"
+
+
+@pytest.fixture
+def clean_output_dirs():
+    out_dir = REPO_ROOT / "test" / "output"
+    err_dir = REPO_ROOT / "test" / "error"
+    for d in (out_dir, err_dir):
+        if d.exists():
+            shutil.rmtree(d)
+        d.mkdir(parents=True)
+    yield out_dir, err_dir
+
+
+def test_submitter_drives_two_local_clusters(clean_output_dirs):
+    out_dir, _ = clean_output_dirs
+
+    clusters = [
+        {
+            "name": "cluster-a",
+            "capacity": 2,
+            "account": "alphaex",
+            "project_root_dir": PROJECT_ROOT_DIR,
+        },
+        {
+            "name": "cluster-b",
+            "capacity": 2,
+            "account": "alphaex",
+            "project_root_dir": PROJECT_ROOT_DIR,
+        },
+    ]
+
+    submitter = Submitter(
+        clusters=clusters,
+        job_list=[(1, 4)],
+        script_path="test/run.sh",
+        export_params={
+            "python_module": "test.my_experiment_entrypoint",
+            "config_file": "test/cfg/variables.json",
+        },
+        sbatch_params={"time": "00:01:00"},
+        duration_between_two_polls=2,
+    )
+
+    start = time.monotonic()
+    submitter.submit()
+    elapsed = time.monotonic() - start
+    assert elapsed < 120, f"submitter.submit() ran for {elapsed:.1f}s; expected <120s"
+
+    for task_id in range(1, 5):
+        out_file = out_dir / f"submit_{task_id}.txt"
+        assert out_file.exists(), f"missing output file {out_file}"
+        text = out_file.read_text()
+        assert "test.my_experiment_entrypoint" in text
+        assert f"sweep_id: {task_id}" in text
+        assert "test/cfg/variables.json" in text

--- a/test/test_submitter_local.py
+++ b/test/test_submitter_local.py
@@ -34,6 +34,11 @@ def clean_output_dirs():
         if d.exists():
             shutil.rmtree(d)
         d.mkdir(parents=True)
+        # Container's alphaex (uid 1000) writes job output through the bind
+        # mount; on Linux that uid won't match the host user, so the dir
+        # must be world-writable. macOS Docker Desktop translates ownership
+        # transparently so this is a no-op there.
+        d.chmod(0o777)
     yield out_dir, err_dir
 
 


### PR DESCRIPTION
Adds a two-container Slurm stack that the submitter can drive over SSH on any dev machine, plus a pytest integration test that exercises the full sbatch/squeue/scp cycle against it. Closes the gap PR 4 left: unit tests cover Submitter's logic in isolation, but until now the real SSH/Slurm seam was never exercised.

What's in docker/
-----------------
- `Dockerfile.slurm`: debian-bullseye-slim + slurm-wlm + munge + openssh-server + python3. Bullseye (slurm 20.11) was chosen over bookworm (slurm 22.05) deliberately — 22.x's cgroup/v2 plugin hard- depends on a systemd dbus service that doesn't exist in a stock container, while 20.11 runs cleanly with `proctrack/linuxproc`.
- `slurm.conf`: minimal single-partition, single-node ("cluster") config; both containers share it because they both set `hostname: cluster` in compose.
- `cgroup.conf`: `CgroupAutomount=no` to keep slurmd off cgroup paths.
- `entrypoint.sh`: creates munge runtime dirs, generates the per- container munge key on first boot, installs the bind-mounted public key as `~alphaex/.ssh/authorized_keys`, starts munged + slurmctld + slurmd, and execs sshd as PID 1.
- `docker-compose.yml`: services `cluster-a` and `cluster-b` on isolated networks, host ports 2221/2222, repo bind-mounted at `/home/alphaex/AlphaEx`, `privileged: true` + `cgroup: host` so slurmd's cgroup probing doesn't trip on Docker Desktop's defaults.
- `setup.sh`: idempotent host-side bootstrap — generates an ed25519 keypair under `docker/keys/`, appends `Host cluster-a` / `Host cluster-b` blocks to `~/.ssh/config` under a guarded marker, builds
  + starts the stack, waits up to 30s for sshd on each container.
- `teardown.sh`: brings the stack down, strips the guarded `~/.ssh/config` block via portable `awk`, removes `known_hosts`.

Test
----
`test/test_submitter_local.py` is skipped unless `ALPHAEX_LOCAL_SLURM=1` is set, so the normal `pytest` invocation collects but doesn't run it. It drives a real Submitter against the two clusters with `job_list=[(1, 4)]`, capacity 2 per cluster, and asserts that `test/output/submit_1.txt` ... `submit_4.txt` exist and contain the entrypoint's expected output.

`test/run.sh` is a short-name copy of `test/submit.sh` ("run.sh", 6 chars) so squeue's default 8-char NAME column doesn't truncate the basename and break `_count_active_jobs`'s substring check. The existing `test/submit.sh` stays as the README's HPC usage example.

CI
--
New `local-slurm` job in `.github/workflows/ci.yml`: spins the stack on `ubuntu-latest`, runs the integration test, surfaces docker logs on failure, runs teardown unconditionally.

Verification (local, macOS + Docker Desktop)
--------------------------------------------
- `bash docker/setup.sh` → both clusters accept ssh within ~6s.
- `ssh cluster-a sinfo` → 1 idle node in partition debug.
- `ALPHAEX_LOCAL_SLURM=1 pytest test/test_submitter_local.py -v` → passes in 2.6s; submit_{1..4}.txt land in test/output/ with the expected entrypoint output.
- `pytest` (no env var) → 54 passed, 1 skipped (unchanged).
- `ruff check`, `pre-commit run --all-files` → clean.
- `bash docker/teardown.sh` → containers gone, ssh config block removed.