### PR TITLE
fix(submitter): surface exit codes, sidestep branch detection, bound polling

### DIFF
--- a/alphaex/submitter.py
+++ b/alphaex/submitter.py
@@ -132,6 +132,31 @@ def _count_active_jobs(squeue_output, script_basename):
     return sum(1 for line in squeue_output.split("\n") if script_basename in line)
 
 
+def _build_git_sync_command(cluster_name, root_dir, repo_url):
+    """Build the ssh command that ensures the project repo is up to date on a cluster.
+
+    If ``root_dir`` exists on the cluster the working tree is hard-reset to the
+    remote's current default branch (resolved via ``origin/HEAD``). This sidesteps
+    the legacy ``git pull origin master`` form, which silently no-ops on every
+    ``main``-default repo (issue #14).
+
+    If ``root_dir`` does not exist it is created by cloning ``repo_url`` into
+    ``<root_dir>/..``; the clone implicitly checks out the remote's default branch.
+
+    The reset is destructive of any cluster-side local changes — a conscious
+    trade-off for "the cluster should mirror the remote".
+    """
+    root_path, _, project_name = root_dir.rpartition("/")
+    update = (
+        f"cd {root_dir} "
+        "&& git fetch origin "
+        "&& git remote set-head origin --auto "
+        "&& git reset --hard origin/HEAD"
+    )
+    clone = f"cd {root_path} && git clone {repo_url} {project_name}"
+    return f"ssh {cluster_name} 'if [ -d {root_dir} ]; then {update}; else {clone}; fi'"
+
+
 class Submitter:
     """
     Create a job submitter and which will ssh to clusters and submit slurm array jobs.
@@ -151,8 +176,15 @@ class Submitter:
             for more details https://slurm.schedmd.com/sbatch.html)
         duration_between_two_polls (int): duration between two polls in seconds.
             Default value is 60.
-        repo_url (str): experiment code's git repo url. If this is not provide,
+        repo_url (str): experiment code's git repo url. If this is not provided,
             the user needs to copy experiment code to each cluster manually.
+            When provided, each cluster's checkout is hard-reset to the remote's
+            current default branch — see ``_build_git_sync_command`` for the
+            destructive-update semantics.
+        max_polls (int): maximum number of poll cycles ``submit()`` may run
+            before raising ``RuntimeError``. ``None`` (the default) means
+            unbounded. Use this to guard against stuck clusters that never
+            drain.
 
     The clusters information is stored in a list of dictionaries.
 
@@ -188,6 +220,7 @@ class Submitter:
         sbatch_params=None,
         duration_between_two_polls=60,
         repo_url=None,
+        max_polls=None,
     ):
         if sbatch_params is None:
             sbatch_params = {}
@@ -198,21 +231,21 @@ class Submitter:
 
         if repo_url is not None:
             for cluster in clusters:
-                root_dir = cluster["project_root_dir"]
-                root_path = "/".join(root_dir.split("/")[:-1])
-                project_name = root_dir.split("/")[-1]
                 self._run_command(
-                    f"ssh {cluster['name']} 'if [ -d {root_dir} ]; "
-                    f"then cd {root_dir}; git pull origin master; "
-                    f"else cd {root_path}; git clone {repo_url} {project_name}; fi'"
+                    _build_git_sync_command(
+                        cluster["name"], cluster["project_root_dir"], repo_url
+                    ),
+                    check=True,
                 )
 
         for cluster in clusters:
             for remote_path, local_path in zip(
                 cluster["exp_results_from"], cluster["exp_results_to"]
             ):
-                self._run_command(f"ssh {cluster['name']} 'mkdir -p {remote_path}'")
-                self._run_command(f"mkdir -p {local_path}")
+                self._run_command(
+                    f"ssh {cluster['name']} 'mkdir -p {remote_path}'", check=True
+                )
+                self._run_command(f"mkdir -p {local_path}", check=True)
 
         self.clusters = clusters.copy()
         self.script_path = script_path
@@ -222,17 +255,39 @@ class Submitter:
         self.job_list = _normalize_job_list(job_list)
         self.starting_job_list_index = 0
         self.starting_job_num = self.job_list[0][0]
+        self.max_polls = max_polls
 
-    def _run_command(self, cmd):
+    def _run_command(self, cmd, check=False):
         """Single seam wrapping subprocess so tests can mock it.
 
-        Mirrors ``os.popen(cmd).read()`` semantics: captures stdout (returned
-        as text) and lets stderr inherit so failures stay visible.
+        Captures both stdout and stderr as text and prints them to keep the
+        live-tail UX of the previous ``os.popen`` form. ``stdout`` is returned;
+        callers that need ``stderr`` go through the raised exception below.
+
+        When ``check`` is ``True`` and the command's return code is non-zero,
+        raises ``subprocess.CalledProcessError`` carrying stdout and stderr.
+        This is how the orchestrator turns a failed ``sbatch`` / ``scp`` / ssh
+        into a loud failure instead of a silent no-op (issue #12).
         """
         print(cmd)
-        result = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, text=True)
+        result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
         print(result.stdout, end="")
+        if result.stderr:
+            print(result.stderr, end="")
+        if check and result.returncode != 0:
+            raise subprocess.CalledProcessError(
+                result.returncode, cmd, output=result.stdout, stderr=result.stderr
+            )
         return result.stdout
+
+    def _sleep(self, seconds):
+        """Single seam wrapping ``time.sleep`` so tests can mock it.
+
+        Mirrors the ``_run_command`` seam pattern: production sleeps; tests
+        monkeypatch the class attribute to drive the polling loop
+        deterministically without real wall-clock delay.
+        """
+        time.sleep(seconds)
 
     def submit_jobs(self, job_array_string, cluster_name, account, project_root_dir):
         cmd = _build_sbatch_command(
@@ -244,21 +299,23 @@ class Submitter:
             self.export_params,
             self.script_path,
         )
-        self._run_command(cmd)
+        self._run_command(cmd, check=True)
         print(f"submit job array {job_array_string} to {cluster_name}.")
 
     def submit(self):
         for cluster in self.clusters:
-            output = self._run_command(f"ssh {cluster['name']} whoami")
+            output = self._run_command(f"ssh {cluster['name']} whoami", check=True)
             cluster["username"] = output.split("\n")[0]
 
         finish_submitting = False
         temp_clusters = self.clusters.copy()
         script_basename = self.script_path.split("/")[-1]
+        polls = 0
         while True:
             for cluster in temp_clusters[:]:
                 output = self._run_command(
-                    _build_squeue_command(cluster["name"], cluster["username"])
+                    _build_squeue_command(cluster["name"], cluster["username"]),
+                    check=True,
                 )
                 num_current_jobs = _count_active_jobs(output, script_basename)
                 print(f"cluster {cluster['name']} has {num_current_jobs} jobs")
@@ -272,7 +329,8 @@ class Submitter:
                             self._run_command(
                                 _build_scp_command(
                                     cluster["name"], remote_path, local_path
-                                )
+                                ),
+                                check=True,
                             )
                         temp_clusters.remove(cluster)
                     if len(temp_clusters) == 0:
@@ -302,4 +360,10 @@ class Submitter:
                         cluster["project_root_dir"],
                     )
 
-            time.sleep(self.duration_between_two_polls)
+            polls += 1
+            if self.max_polls is not None and polls >= self.max_polls:
+                raise RuntimeError(
+                    f"submit() exceeded max_polls={self.max_polls} without "
+                    f"draining; {len(temp_clusters)} cluster(s) still active"
+                )
+            self._sleep(self.duration_between_two_polls)

--- a/test/test_submitter_unit.py
+++ b/test/test_submitter_unit.py
@@ -1,7 +1,10 @@
+import subprocess
+
 import pytest
 
 from alphaex.submitter import (
     Submitter,
+    _build_git_sync_command,
     _build_job_array_string,
     _build_sbatch_command,
     _build_scp_command,
@@ -237,10 +240,12 @@ class FakeRunner:
         self.responses = responses
         self.queue_iter = iter(responses.get("squeue_sequence", []))
 
-    def __call__(self, cmd):
+    def __call__(self, cmd, check=False):
         # NOTE: monkeypatch assigns this instance as a class attribute on
         # Submitter, so attribute access does NOT bind `self` like a function
         # would. The submitter calls us as `runner(cmd)`, not `runner(self, cmd)`.
+        # `check` is accepted to match the production seam but ignored — the
+        # mock has no failure mode to surface.
         self.calls.append(cmd)
         if "whoami" in cmd:
             return self.responses.get("whoami", "alice") + "\n"
@@ -296,13 +301,18 @@ def test_submitter_init_skips_git_when_repo_url_is_none(submitter_with_runner):
     assert not any("git" in c for c in runner.calls)
 
 
-def test_submitter_init_invokes_git_clone_when_repo_url_given(submitter_with_runner):
+def test_submitter_init_invokes_git_sync_when_repo_url_given(submitter_with_runner):
     runner = FakeRunner({})
     submitter_with_runner(runner, repo_url="https://example.com/repo.git")
     git_calls = [c for c in runner.calls if "git " in c]
     assert len(git_calls) == 1
+    # The first-clone branch must still reach git clone:
     assert "git clone https://example.com/repo.git proj" in git_calls[0]
-    assert "git pull origin master" in git_calls[0]
+    # The update-existing-checkout branch hard-resets to the remote's default
+    # branch instead of guessing `master` (issue #14).
+    assert "git fetch origin" in git_calls[0]
+    assert "git remote set-head origin --auto" in git_calls[0]
+    assert "git reset --hard origin/HEAD" in git_calls[0]
 
 
 def test_submit_happy_path_drains_queue_and_copies_results(
@@ -330,3 +340,144 @@ def test_submit_happy_path_drains_queue_and_copies_results(
     assert "--time=00:10:00" in sbatches[0]
     assert "--export=k=v" in sbatches[0]
     assert "scp -r cedar:/home/alice/proj/test/output/* test/output/" in runner.calls
+
+
+# ----- _build_git_sync_command (issue #14) -----
+
+
+def test_build_git_sync_command_ssh_wraps_with_cluster_name():
+    cmd = _build_git_sync_command(
+        cluster_name="cedar",
+        root_dir="/home/alice/proj",
+        repo_url="https://example.com/repo.git",
+    )
+    assert cmd.startswith("ssh cedar '")
+    assert cmd.endswith("'")
+
+
+def test_build_git_sync_command_uses_origin_head_reset_when_dir_exists():
+    cmd = _build_git_sync_command(
+        cluster_name="cedar",
+        root_dir="/home/alice/proj",
+        repo_url="https://example.com/repo.git",
+    )
+    assert (
+        "if [ -d /home/alice/proj ]; "
+        "then cd /home/alice/proj "
+        "&& git fetch origin "
+        "&& git remote set-head origin --auto "
+        "&& git reset --hard origin/HEAD; "
+        "else cd /home/alice "
+        "&& git clone https://example.com/repo.git proj; "
+        "fi"
+    ) in cmd
+
+
+def test_build_git_sync_command_derives_clone_target_from_root_dir():
+    cmd = _build_git_sync_command(
+        cluster_name="cedar",
+        root_dir="/home/alice/deep/proj",
+        repo_url="https://example.com/repo.git",
+    )
+    assert "cd /home/alice/deep && git clone https://example.com/repo.git proj" in cmd
+
+
+# ----- Submitter._run_command exit-code handling (issue #12) -----
+
+
+def _make_completed(returncode, stdout="", stderr=""):
+    return subprocess.CompletedProcess(
+        args="dummy", returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+@pytest.fixture
+def submitter_no_io():
+    """Submitter whose __init__ does not invoke _run_command.
+
+    Achieved by omitting `repo_url` and `exp_results_{from,to}`, so the init
+    loops over zero work and never touches subprocess. Tests can then exercise
+    `_run_command` directly without needing to mock the seam first.
+    """
+    return Submitter(
+        clusters=[
+            {
+                "name": "cedar",
+                "capacity": 1,
+                "account": "def-sutton",
+                "project_root_dir": "/home/alice/proj",
+            }
+        ],
+        job_list=[(1, 1)],
+        script_path="test/submit.sh",
+    )
+
+
+def test_run_command_returns_stdout_on_success(monkeypatch, submitter_no_io):
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: _make_completed(0, stdout="ok\n")
+    )
+    assert submitter_no_io._run_command("echo ok") == "ok\n"
+
+
+def test_run_command_returns_stdout_when_check_false_and_returncode_nonzero(
+    monkeypatch, submitter_no_io
+):
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **k: _make_completed(1, stdout="partial\n", stderr="boom\n"),
+    )
+    assert submitter_no_io._run_command("false", check=False) == "partial\n"
+
+
+def test_run_command_raises_when_check_true_and_returncode_nonzero(
+    monkeypatch, submitter_no_io
+):
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **k: _make_completed(
+            42, stdout="partial out\n", stderr="permission denied\n"
+        ),
+    )
+    with pytest.raises(subprocess.CalledProcessError) as exc_info:
+        submitter_no_io._run_command("false", check=True)
+    assert exc_info.value.returncode == 42
+    assert exc_info.value.stdout == "partial out\n"
+    assert exc_info.value.stderr == "permission denied\n"
+
+
+# ----- Submitter._sleep seam + max_polls cap (issue #13) -----
+
+
+def test_submit_calls_sleep_seam_between_polls(monkeypatch, submitter_with_runner):
+    # Two empty squeue responses: iter 1 submits (and finishes); iter 2
+    # observes empty queue, copies results, and returns. One sleep between.
+    runner = FakeRunner({"squeue_sequence": ["JOBID NAME ST\n"] * 2})
+    sleep_calls = []
+    monkeypatch.setattr(Submitter, "_sleep", lambda self, s: sleep_calls.append(s))
+    submitter = submitter_with_runner(runner, duration_between_two_polls=7)
+    submitter.submit()
+    assert sleep_calls == [7]
+
+
+def test_submit_raises_runtime_error_when_max_polls_exceeded(submitter_with_runner):
+    # squeue always returns full → cluster never drains. Without the cap this
+    # is the spin-forever scenario the issue calls out.
+    busy = "1 submit.sh R alice\n2 submit.sh R alice\n3 submit.sh R alice\n"
+    runner = FakeRunner({"squeue_sequence": [busy] * 10})
+    submitter = submitter_with_runner(runner, max_polls=3, duration_between_two_polls=0)
+    with pytest.raises(RuntimeError, match="max_polls=3"):
+        submitter.submit()
+
+
+def test_submit_unbounded_by_default(monkeypatch, submitter_with_runner):
+    # max_polls defaults to None — no RuntimeError, just relies on the
+    # happy-path drain. This guards against a regression where someone
+    # tightens the default.
+    runner = FakeRunner({"squeue_sequence": ["JOBID NAME ST\n"] * 2})
+    monkeypatch.setattr(Submitter, "_sleep", lambda self, s: None)
+    submitter = submitter_with_runner(runner)
+    assert submitter.max_polls is None
+    submitter.submit()  # must complete cleanly


### PR DESCRIPTION
## Summary

Three related correctness/testability fixes in `Submitter`, all touching the same module:

- **`_run_command` now surfaces exit codes (#12).** Captures stderr in addition to stdout and accepts a `check` kwarg. Every internal call site (\`git fetch/reset\`, remote/local \`mkdir\`, \`whoami\`, \`squeue\`, \`sbatch\`, \`scp\`) requests strict mode, so a non-zero return code now raises \`subprocess.CalledProcessError\` instead of silently no-opping. The exception carries both stdout and stderr for debuggability.
- **Git sync sidesteps the branch question (#14).** Introduces \`_build_git_sync_command\` and replaces \`git pull origin master\` with \`git fetch origin && git remote set-head origin --auto && git reset --hard origin/HEAD\`. Works on both \`master\`- and \`main\`-default repos at the cost of clobbering cluster-side local changes — a deliberate trade-off documented in the helper's docstring (prior behavior was a silent no-op for any modern repo).
- **Polling loop is bounded + testable (#13).** Adds a \`_sleep\` instance-method seam (mirrors \`_run_command\`) and a \`max_polls\` init parameter. Production keeps the unbounded default; tests monkeypatch \`_sleep\` and bound the loop to drive deterministic scenarios. Stuck clusters now surface as a \`RuntimeError\` instead of an infinite spin when the cap is set.

Coverage on \`alphaex/submitter.py\`: **95% → 100%**.

## Design notes

- The \`check\` parameter defaults to \`False\` to preserve the seam's contract for any external code that monkeypatches \`_run_command\`. Every internal site passes \`check=True\` explicitly, which doubles as documentation of intent at each call site.
- \`_build_git_sync_command\` is a pure module-level helper, matching the existing pattern from #9 (\`_build_sbatch_command\` et al.) — easy to unit-test, hides the path-derivation and command-shape choices behind a 3-arg interface.
- The \`max_polls\` check fires after each outer iteration that didn't drain, so the early \`return\` on success is never blocked by the cap.

## Test plan

- [x] \`uv run pytest --cov=alphaex --cov-report=term-missing\` — 63 passed, 1 skipped (the docker integration test), \`alphaex/submitter.py\` 100% coverage.
- [x] \`uv run ruff check alphaex/ test/\` — all checks pass.
- [x] \`uv run ruff format --check alphaex/ test/\` — already formatted.
- [x] \`uv run pre-commit run --all-files\` — both hooks pass.
- [ ] Local mini-slurm integration (\`ALPHAEX_LOCAL_SLURM=1 uv run pytest test/test_submitter_local.py -v\`) — relies on docker; CI's \`local-slurm\` job will exercise the same path automatically.

## Behavior changes worth flagging for downstream users

- Submitter now raises \`subprocess.CalledProcessError\` if any of \`sbatch\`, \`scp\`, \`ssh whoami\`, \`ssh mkdir\`, local \`mkdir\`, or the git sync fails. Users relying on the old silent-failure behavior will see new exceptions — the intended bug fix.
- Git sync uses \`git reset --hard origin/HEAD\`, destructive of cluster-side local changes. The old \`git pull origin master\` was a silent no-op for any repo whose default branch is \`main\`.
- \`max_polls=None\` default preserves today's unbounded loop; callers opting into a cap get a clean \`RuntimeError\` instead of a hang.

Closes #12, #13, #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)