### PR TITLE
chore: quick-polish sweep across Sweeper, Submitter docstring, and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ uv pip install -e .
 ### What is Submitter
 Think about the case when you have 1000 jobs to run and 3 computer clusters available.
 It is not easy to manually assign jobs to clusters in an effective way.
-One reason is that the speed of computing varies across different cluster.
+One reason is that the speed of computing varies across different clusters.
 The other reason is that clusters may have different restrictions on the number of jobs submitted.
 Submitter automatically submits all jobs for you in a simple way.
 Here is how it works.
@@ -94,7 +94,11 @@ Host <cluster name>
 Next time when you want to add a new cluster, just repeat step 2 and step 3.
 
 #### Example
-Now you can use submitter. test/test_submitter.py is a good example to start with.
+Now you can use submitter. `test/test_submitter.py` is a good example to start with.
+The values that vary per HPC account (`project_root_dir`, `account`, `repo_url`)
+are read from `ALPHAEX_PROJECT_ROOT`, `ALPHAEX_ACCOUNT`, and `ALPHAEX_REPO_URL`
+in that file, so you can run it without editing — see the module docstring there
+for details. The literal values below are for illustration only.
 
 ```
 from alphaex.submitter import Submitter
@@ -157,7 +161,7 @@ Usually you would need to specify some parameters in your array-job submission s
 However, you are also allowed to specify them here instead of in your array-job submission script.
 In particular, you can specify parameters required by sbatch (e.g., time, mem-per-cpu) using sbatch_params,
 and you can specify other parameters you would like to pass to the sbatch script, using export_params.
-In this way, your array-job submission script can be common to many experiments and thus reuseable.
+In this way, your array-job submission script can be common to many experiments and thus reusable.
 `test/submit.sh` is an example of the array-job submission script (For more details about slurm, please refer to the [user manual](https://slurm.schedmd.com/).
 
 ```
@@ -180,13 +184,13 @@ In this simple example, each job outputs the `SLURM_ARRAY_TASK_ID` and the confi
 And the output will be written to `test/output/submit_<SLURM_ARRAY_TASK_ID>.txt`.
 
 From this project root directory run `python -m test.test_submitter` in the server.
-Since the total capacity of mp2 and cedar are less than the total number jobs you want to run,
+Since the total capacity of mp2 and cedar are less than the total number of jobs you want to run,
 submitter can not submit all of the jobs to these two clusters at once.
 Instead, it will submit array jobs with array indices 1-3 to cluster mp2, and submit array jobs 4,6,102 to cluster cedar.
 After that, it will monitor whether there are any submitted jobs finished.
 And if there are any, the submitter will submit same number of new jobs as the finished ones until all of the 16 jobs are submitted.
 
-After all jobs are submitted and one of the clusters finishes its all jobs, submitter will copy experimental results from that cluster to the server .
+After all jobs are submitted and one of the clusters finishes its all jobs, submitter will copy experimental results from that cluster to the server.
 And you can see your results in `test/output`
 
 

--- a/alphaex/submitter.py
+++ b/alphaex/submitter.py
@@ -151,7 +151,7 @@ class Submitter:
             for more details https://slurm.schedmd.com/sbatch.html)
         duration_between_two_polls (int): duration between two polls in seconds.
             Default value is 60.
-        repo_url (str): experiment code's git repo url. If this is not provide,
+        repo_url (str): experiment code's git repo url. If this is not provided,
             the user needs to copy experiment code to each cluster manually.
 
     The clusters information is stored in a list of dictionaries.

--- a/alphaex/sweeper.py
+++ b/alphaex/sweeper.py
@@ -31,7 +31,7 @@ class Sweeper:
         for key, values in config_dict.items():
             num_combinations = 0
             for value in values:
-                if type(value) is dict:
+                if isinstance(value, dict):
                     self.set_num_combinations_helper(value)
                     num_combinations += value["num_combinations"]
                 else:
@@ -59,7 +59,7 @@ class Sweeper:
             value, relative_idx = self.get_value_and_relative_idx(
                 values, int(idx / cumulative) % num_combinations
             )
-            if type(value) is dict:
+            if isinstance(value, dict):
                 self.parse_helper(relative_idx, value, rtv_dict)
             else:
                 rtv_dict[variable] = value
@@ -69,7 +69,7 @@ class Sweeper:
     def get_num_combinations(values):
         num_values = 0
         for value in values:
-            if type(value) is dict:
+            if isinstance(value, dict):
                 num_values += value["num_combinations"]
             else:
                 num_values += 1
@@ -79,14 +79,20 @@ class Sweeper:
     def get_value_and_relative_idx(values, idx):
         num_values = 0
         for value in values:
-            if type(value) is dict:
+            if isinstance(value, dict):
                 temp = value["num_combinations"]
             else:
                 temp = 1
             if idx < num_values + temp:
                 return value, idx - num_values
             num_values += temp
-        return num_values
+        # Pre-fix: returned `num_values` (a bare int) instead of a tuple, so
+        # the caller's `value, relative_idx = ...` unpack exploded with a
+        # misleading TypeError one frame up. Raising here surfaces the real
+        # cause at the source (issue #22).
+        raise IndexError(
+            f"idx {idx} exceeds total combinations {num_values} in {values!r}"
+        )
 
     def search(self, search_dict, num_runs):
         """

--- a/test/test_submitter.py
+++ b/test/test_submitter.py
@@ -3,7 +3,41 @@
 # Permission given to modify the code as long as you keep this        #
 # declaration at the top                                              #
 #######################################################################
+"""Runnable Submitter usage example against a real HPC cluster.
+
+This file is the canonical example referenced from README.md. The clusters
+listed below assume you have ssh access to ``cedar`` and ``mp2`` (compute
+canada style) configured in ``~/.ssh/config``. Tailor the names, capacities,
+and result paths to whatever clusters you have access to.
+
+Three values that vary per-account are read from environment variables so
+the file is runnable as-is without editing:
+
+  ALPHAEX_PROJECT_ROOT  - absolute path on each cluster where AlphaEx is
+                          cloned (e.g. /home/<you>/projects/<account>/<you>/AlphaEx).
+  ALPHAEX_ACCOUNT       - your slurm account name (e.g. def-sutton, rrg-whitem).
+  ALPHAEX_REPO_URL      - your fork of AlphaEx (defaults to upstream).
+
+Example:
+
+    ALPHAEX_PROJECT_ROOT=/home/alice/projects/def-sutton/alice/AlphaEx \\
+    ALPHAEX_ACCOUNT=def-sutton \\
+    python -m test.test_submitter
+
+This file is intentionally excluded from pytest collection (see
+``[tool.pytest.ini_options]`` in ``pyproject.toml``) - it talks to live
+clusters and is meant to be run by hand.
+"""
+
+import os
+
 from alphaex.submitter import Submitter
+
+PROJECT_ROOT_DIR = os.environ.get("ALPHAEX_PROJECT_ROOT", "<set ALPHAEX_PROJECT_ROOT>")
+ACCOUNT = os.environ.get("ALPHAEX_ACCOUNT", "<set ALPHAEX_ACCOUNT>")
+REPO_URL = os.environ.get(
+    "ALPHAEX_REPO_URL", "https://github.com/AmiiThinks/AlphaEx.git"
+)
 
 
 def test_submitter():
@@ -11,28 +45,27 @@ def test_submitter():
         {
             "name": "cedar",
             "capacity": 3,
-            "account": "def-sutton",
-            "project_root_dir": "/home/yiwan/projects/def-sutton/yiwan/AlphaEx",
+            "account": ACCOUNT,
+            "project_root_dir": PROJECT_ROOT_DIR,
             "exp_results_from": [
-                "/home/yiwan/projects/def-sutton/yiwan/AlphaEx/test/output",
-                "/home/yiwan/projects/def-sutton/yiwan/AlphaEx/test/error",
+                f"{PROJECT_ROOT_DIR}/test/output",
+                f"{PROJECT_ROOT_DIR}/test/error",
             ],
             "exp_results_to": ["test/output", "test/error"],
         },
         {
             "name": "mp2",
             "capacity": 3,
-            "account": "def-sutton",
-            "project_root_dir": "/home/yiwan/projects/def-sutton/yiwan/AlphaEx",
+            "account": ACCOUNT,
+            "project_root_dir": PROJECT_ROOT_DIR,
             "exp_results_from": [
-                "/home/yiwan/projects/def-sutton/yiwan/AlphaEx/test/output",
-                "/home/yiwan/projects/def-sutton/yiwan/AlphaEx/test/error",
+                f"{PROJECT_ROOT_DIR}/test/output",
+                f"{PROJECT_ROOT_DIR}/test/error",
             ],
             "exp_results_to": ["test/output", "test/error"],
         },
     ]
     job_list = [(1, 4), 6, (102, 105), 100, (8, 12), 107]
-    repo_url = "https://github.com/yiwan-rl/AlphaEx.git"
     script_path = "test/submit.sh"
     submitter = Submitter(
         clusters,
@@ -47,7 +80,7 @@ def test_submitter():
             "mem-per-cpu": "1G",
             "job-name": script_path.split("/")[1],
         },
-        repo_url=repo_url,
+        repo_url=REPO_URL,
         duration_between_two_polls=60,
     )
     submitter.submit()

--- a/test/test_sweeper_unit.py
+++ b/test/test_sweeper_unit.py
@@ -232,6 +232,20 @@ def test_get_value_and_relative_idx_with_dict_value():
     assert rel == 0
 
 
+def test_get_value_and_relative_idx_raises_when_idx_out_of_range():
+    # Pre-fix: the fallback returned a bare int, so callers' tuple unpack would
+    # explode with a misleading "cannot unpack non-iterable int" one frame up.
+    # Post-fix: raise IndexError at the source with a useful message (issue #22).
+    with pytest.raises(IndexError, match="idx 99"):
+        Sweeper.get_value_and_relative_idx(["a", "b", "c"], 99)
+
+
+def test_get_value_and_relative_idx_raises_at_exact_boundary():
+    # idx == len(values) is the smallest out-of-range value for a leaf list.
+    with pytest.raises(IndexError):
+        Sweeper.get_value_and_relative_idx(["a", "b", "c"], 3)
+
+
 def test_minimal_single_value_sweep_runs_increment(tmp_path):
     cfg_path = _write_cfg(tmp_path, {"alpha": ["only"]})
     s = Sweeper(cfg_path)


### PR DESCRIPTION
## Summary

Bundles four small, low-risk cleanups that share a common theme: "things a reader can grep but the linter doesn't catch."

- **#22 — Sweeper fallback returns the wrong type.** The unreachable fallback at the end of \`Sweeper.get_value_and_relative_idx\` returned a bare \`int\` while every other return path yielded a \`(value, relative_idx)\` tuple. If the path ever fires the caller's unpack explodes with a misleading \`TypeError\` one frame up. Replaced with an explicit \`IndexError\` carrying \`idx\`, the total combinations, and the offending values list. Two new unit tests pin this in place. Coverage on \`alphaex/sweeper.py\` goes from 99% to 100%.
- **#23 — \`type(x) is dict\` → \`isinstance(x, dict)\`.** Four sites in \`alphaex/sweeper.py\`. Idiomatic Python; handles dict subclasses (\`OrderedDict\`, etc.) correctly. Behavior-preserving for the existing fixtures, which the test suite confirms.
- **#24 — Docstring + README typos.** Submitter docstring: \`"If this is not provide"\` → \`"If this is not provided"\`. README: \`"different cluster"\` → \`"different clusters"\`, \`"reuseable"\` → \`"reusable"\`, \`"total number jobs"\` → \`"total number of jobs"\`, trailing space before a period. Note: the issue body also flagged a non-existent \`total_num_jobs\` parameter in the Submitter docstring; that was already cleaned up in #9 (the args section already says \`job_list\`), verified here.
- **#25 — \`test/test_submitter.py\` ships hardcoded HPC paths.** The file is the README's canonical Submitter example but encodes a previous maintainer's compute-canada account (\`/home/yiwan/projects/def-sutton/yiwan/AlphaEx\`, \`def-sutton\`, \`yiwan-rl\` fork URL). New users copy-paste it and get baffling errors. Switched to \`os.environ.get("ALPHAEX_PROJECT_ROOT", "<set ALPHAEX_PROJECT_ROOT>")\` (plus \`ALPHAEX_ACCOUNT\`, \`ALPHAEX_REPO_URL\`) with a module docstring explaining the env vars; the file is now runnable as \`ALPHAEX_PROJECT_ROOT=... ALPHAEX_ACCOUNT=... python -m test.test_submitter\`. README gains a one-line callout above the example pointing readers at the env vars; the literal dict in the README is preserved for documentation clarity.

## Design notes

- The \`IndexError\` message includes \`idx\`, \`num_values\`, and \`values!r\` so a future reader who hits the path doesn't need to reconstruct the inputs from the stack trace.
- \`test/test_submitter.py\` keeps its placeholder defaults (\`"<set ALPHAEX_PROJECT_ROOT>"\` etc.) rather than raising on import — the file is pytest-excluded (\`addopts = "--ignore=test/test_submitter.py"\`) but \`python -c "import test.test_submitter"\` and ruff's import-sort still need to work in CI. Running \`python -m test.test_submitter\` without the env vars will fail downstream at the actual \`ssh\` command with a clearer error than an \`ImportError\` would give.

## Test plan

- [x] \`uv run pytest --cov=alphaex --cov-report=term-missing\` — 56 passed, 1 skipped, sweeper.py 100%.
- [x] \`uv run ruff check alphaex/ test/ && uv run ruff format --check alphaex/ test/\` — clean.
- [x] \`uv run python -c "import test.test_submitter as m; print(m.PROJECT_ROOT_DIR)"\` — placeholder visible when env vars unset.
- [x] \`uv run pre-commit run --all-files\` — both hooks pass.

Closes #22, #23, #24, #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)