### PR TITLE
ci: cache slurm docker image, upload coverage, watch docker base image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,9 @@ updates:
     groups:
       actions-minor-and-patch:
         update-types: ["minor", "patch"]
+
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,16 @@ jobs:
       - name: Run pytest
         run: |
           source .venv/bin/activate
-          pytest --cov=alphaex --cov-report=term-missing
+          pytest --cov=alphaex --cov-report=term-missing --cov-report=xml
+      - name: Upload coverage to Codecov
+        # Upload from one matrix slot only — the 4 Python versions all produce
+        # equivalent reports, so uploading each one just adds noise. (#20)
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   local-slurm:
     runs-on: ubuntu-latest
@@ -57,7 +66,24 @@ jobs:
         run: uv venv --python 3.12
       - name: Install dev extras
         run: uv pip install -e ".[dev]"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build slurm cluster image with GHA cache
+        # Cold builds of bullseye + apt-install slurm/munge/sshd cost ~60-90s
+        # per PR. The buildx GHA cache makes warm runs near-instant. (#18)
+        uses: docker/build-push-action@v6
+        with:
+          context: docker
+          file: docker/Dockerfile.slurm
+          tags: alphaex-slurm
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: Bring up mini-slurm
+        # ALPHAEX_PREBUILT_IMAGE tells setup.sh to skip `--build` since the
+        # buildx step above already produced the `alphaex-slurm` image.
+        env:
+          ALPHAEX_PREBUILT_IMAGE: "1"
         run: bash docker/setup.sh
       - name: Run local-slurm integration test
         env:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 <p><img src="./images/alphaex_logo.jpg" alt="test" width="200" height="200"></p>
 
+[![CI](https://github.com/dantp-ai/AlphaEx/actions/workflows/ci.yml/badge.svg)](https://github.com/dantp-ai/AlphaEx/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/dantp-ai/AlphaEx/graph/badge.svg)](https://codecov.io/gh/dantp-ai/AlphaEx)
+
 AlphaEx (Alpha Experiment) is a python toolkit that helps you manage large number of experiments easily and efficiently.
 
 With AlphaEx, you can:

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -48,8 +48,15 @@ $MARK_END
 EOF
 fi
 
-echo "[setup] building and starting the mini-slurm stack..."
-docker compose -f "$DOCKER_DIR/docker-compose.yml" up -d --build
+echo "[setup] starting the mini-slurm stack..."
+# CI's `local-slurm` job pre-builds the image via buildx + the GHA cache,
+# then exports ALPHAEX_PREBUILT_IMAGE=1 so we skip the redundant compose
+# build pass here. Local devs leave it unset and get the normal build.
+if [ "${ALPHAEX_PREBUILT_IMAGE:-}" = "1" ]; then
+    docker compose -f "$DOCKER_DIR/docker-compose.yml" up -d
+else
+    docker compose -f "$DOCKER_DIR/docker-compose.yml" up -d --build
+fi
 
 wait_for_ssh() {
     local host=$1


### PR DESCRIPTION
## Summary

Three CI / infra cleanups, all in \`.github/\` and \`docker/\`:

- **#18 — Cache the slurm cluster image between \`local-slurm\` runs.** Cold builds of \`bullseye-slim\` + apt-installing \`slurm-wlm\` + \`munge\` + \`openssh-server\` + \`python3\` cost ~60-90s per PR. The new flow uses \`docker/setup-buildx-action@v3\` and \`docker/build-push-action@v6\` with the GitHub Actions cache backend (\`cache-from: type=gha\`, \`cache-to: type=gha,mode=max\`) to build the image once per Dockerfile change. \`docker/setup.sh\` honors \`ALPHAEX_PREBUILT_IMAGE=1\` to skip its own \`docker compose --build\` pass when CI has already produced the image; local devs leave it unset and get the unchanged build path. Cache hits should drop the \`local-slurm\` job from ~3min to ~30-60s.
- **#20 — Upload coverage to codecov + add badges.** \`pytest\` now emits \`coverage.xml\` in addition to the existing terminal report. A new \`codecov/codecov-action@v5\` step uploads it, gated on \`matrix.python-version == '3.12'\` so we send one report per CI run instead of four duplicates. \`fail_ci_if_error: false\` keeps the build green when codecov is briefly unavailable. README gains a CI status badge and a codecov badge above the description.
- **#21 — Watch the docker base image.** \`.github/dependabot.yml\` gains a \`package-ecosystem: docker\` entry rooted at \`/docker\` (weekly, limit 2) so when \`debian:bullseye-slim\` ages out, dependabot opens a PR instead of CI rotting silently.

## Design notes

- The \`ALPHAEX_PREBUILT_IMAGE\` knob is the smallest possible API between CI and \`setup.sh\`. The alternative — always rebuilding even in CI — would double-build and waste the cache. The alternative — making CI invoke compose directly without setup.sh — would bypass the SSH config and key wiring that setup.sh handles.
- The Codecov action only runs from the 3.12 matrix slot because all four Python versions exercise the same coverage paths. Multiple uploads work but generate noise in the codecov UI and pay the upload cost four times for no signal gain.
- Both badges are pinned to \`dantp-ai/AlphaEx\` (your fork, not the upstream).

## #19 — branch protection (not included)

The remaining "CI polish" issue #19 — *require* lint / test (3.9-3.12) / local-slurm as passing checks before merge — is a **repo Settings change**, not a code change. Apply it manually at:

\`Settings → Branches → Branch protection rules → master\`

and select these required status checks:

- \`lint\`
- \`test (3.9)\`, \`test (3.10)\`, \`test (3.11)\`, \`test (3.12)\`
- \`local-slurm\`

Intentionally not part of this PR so you stay in control of when enforcement kicks in.

## Codecov setup (one-time)

The badge will say "unknown" until the first successful upload completes. Sign in at codecov.io with your GitHub account and enable the \`AlphaEx\` repo — the upload token is optional for public repos but recommended for resilience against rate limits. If you set one, add it as repo secret \`CODECOV_TOKEN\`.

## Test plan

- [x] \`bash -n docker/setup.sh\` — script parses.
- [x] \`python -c 'import yaml; yaml.safe_load(open(\".github/workflows/ci.yml\"))'\` — workflow YAML is valid.
- [x] \`uv run pytest && uv run ruff check && uv run ruff format --check\` — unaffected tests stay green; lint/format clean.
- [ ] First CI run on this PR will exercise the new buildx-with-cache + codecov upload paths.

Closes #18, #20, #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)