### PR TITLE
refactor(sweeper): encapsulate counts, privatize helpers, simplify search

### DIFF
--- a/alphaex/sweeper.py
+++ b/alphaex/sweeper.py
@@ -15,84 +15,74 @@ class Sweeper:
 
     def __init__(self, config_file):
         with open(config_file) as f:
-            self.config_dict = json.load(f)
-        self.total_combinations = 1
-        self.keys_list = []
-        self.set_num_combinations()
-        self.keys_set = set(self.keys_list)
+            self._config_dict = json.load(f)
+        # Number of combinations each dict node yields, keyed by id() of the
+        # node. Kept in this class-owned map instead of being written back into
+        # the parsed config, so the user's data is never mutated (issue #39).
+        # _config_dict is held for the Sweeper's lifetime, so the ids stay valid.
+        self._counts = {}
+        self._keys = []
+        self.total_combinations = self._count(self._config_dict)
+        self._keys_set = set(self._keys)
 
-    def set_num_combinations(self):
-        # calculating total_combinations
-        self.set_num_combinations_helper(self.config_dict)
-        self.total_combinations = self.config_dict["num_combinations"]
+    def _count(self, node):
+        """Compute and memoize how many combinations the dict ``node`` yields.
 
-    def set_num_combinations_helper(self, config_dict):
-        num_combinations_in_list = 1
-        for key, values in config_dict.items():
-            num_combinations = 0
+        A dict's count is the product over its keys of the key's list count; a
+        list's count is the sum of its elements' counts; a scalar counts as 1.
+        Records every scalar variable name in ``self._keys`` along the way.
+        """
+        total = 1
+        for key, values in node.items():
+            list_count = 0
             for value in values:
                 if isinstance(value, dict):
-                    self.set_num_combinations_helper(value)
-                    num_combinations += value["num_combinations"]
+                    list_count += self._count(value)
                 else:
-                    num_combinations += 1
-                    self.keys_list.append(key)
-            num_combinations_in_list *= num_combinations
-        config_dict["num_combinations"] = num_combinations_in_list
-        return num_combinations_in_list
+                    list_count += 1
+                    self._keys.append(key)
+            total *= list_count
+        self._counts[id(node)] = total
+        return total
+
+    def _combinations_of(self, value):
+        """Number of combinations a single list element contributes."""
+        return self._counts[id(value)] if isinstance(value, dict) else 1
 
     def parse(self, idx):
-        rtn_dict = dict()
-        rtn_dict["run"] = int(idx / self.total_combinations)
-
-        self.parse_helper(idx, self.config_dict, rtn_dict)
-
+        rtn_dict = {"run": idx // self.total_combinations}
+        self._parse(idx, self._config_dict, rtn_dict)
         return rtn_dict
 
-    def parse_helper(self, idx, config_dict, rtv_dict):
+    def _parse(self, idx, node, rtn_dict):
+        # Mixed-radix decode: each key is a digit whose base is its list count,
+        # and `cumulative` is the place value of the current digit.
         cumulative = 1
-        # Populating sweep variables
-        for variable, values in config_dict.items():
-            if variable == "num_combinations":
-                continue
-            num_combinations = self.get_num_combinations(values)
-            value, relative_idx = self.get_value_and_relative_idx(
-                values, int(idx / cumulative) % num_combinations
+        for variable, values in node.items():
+            num_combinations = sum(self._combinations_of(v) for v in values)
+            value, relative_idx = self._select(
+                values, (idx // cumulative) % num_combinations
             )
             if isinstance(value, dict):
-                self.parse_helper(relative_idx, value, rtv_dict)
+                self._parse(relative_idx, value, rtn_dict)
             else:
-                rtv_dict[variable] = value
+                rtn_dict[variable] = value
             cumulative *= num_combinations
 
-    @staticmethod
-    def get_num_combinations(values):
-        num_values = 0
+    def _select(self, values, idx):
+        """Return ``(value, relative_idx)`` for the element of ``values`` that
+        index ``idx`` falls into, where each dict element spans
+        ``_combinations_of`` slots.
+        """
+        offset = 0
         for value in values:
-            if isinstance(value, dict):
-                num_values += value["num_combinations"]
-            else:
-                num_values += 1
-        return num_values
-
-    @staticmethod
-    def get_value_and_relative_idx(values, idx):
-        num_values = 0
-        for value in values:
-            if isinstance(value, dict):
-                temp = value["num_combinations"]
-            else:
-                temp = 1
-            if idx < num_values + temp:
-                return value, idx - num_values
-            num_values += temp
-        # Pre-fix: returned `num_values` (a bare int) instead of a tuple, so
-        # the caller's `value, relative_idx = ...` unpack exploded with a
-        # misleading TypeError one frame up. Raising here surfaces the real
-        # cause at the source (issue #22).
-        raise IndexError(
-            f"idx {idx} exceeds total combinations {num_values} in {values!r}"
-        )
+            width = self._combinations_of(value)
+            if idx < offset + width:
+                return value, idx - offset
+            offset += width
+        # A bare-int fallback used to make the caller's tuple unpack explode one
+        # frame up; raise at the source with a useful message instead (issue #22).
+        raise IndexError(f"idx {idx} exceeds total combinations {offset} in {values!r}")
 
     def search(self, search_dict, num_runs):
         """
@@ -110,40 +100,24 @@ class Sweeper:
         :return: the search result,
         a list of combinations of variables related to the key words
         """
-
-        # find in search dict keys that don't appear in sweeper
-        delete = [key for key in search_dict if key not in self.keys_set]
-        temp_search_dict = search_dict.copy()
-        # delete keys
-        for key in delete:
-            del temp_search_dict[key]
+        # Drop keys that are not swept variables; they cannot constrain a result.
+        relevant = {k: v for k, v in search_dict.items() if k in self._keys_set}
 
         search_result_list = []
-
         for idx in range(self.total_combinations):
-            temp_dict = self.parse(idx)
-
-            valid_temp_dict = True
-            for key in temp_search_dict:
-                if key not in temp_dict:
-                    valid_temp_dict = False
-                    break
-
-            if valid_temp_dict is False:
-                continue
-
-            search_result_list.append(
-                {
-                    "ids": [
-                        idx + run * self.total_combinations for run in range(num_runs)
-                    ]
-                }
+            combination = self.parse(idx)
+            matches = all(
+                key in combination and combination[key] == value
+                for key, value in relevant.items()
             )
-
-            for key, value in temp_dict.items():
-                if key in temp_search_dict and temp_search_dict[key] != value:
-                    search_result_list = search_result_list[:-1]
-                    break
-                search_result_list[-1][key] = value
-
+            if matches:
+                search_result_list.append(
+                    {
+                        "ids": [
+                            idx + run * self.total_combinations
+                            for run in range(num_runs)
+                        ],
+                        **combination,
+                    }
+                )
         return search_result_list

--- a/test/test_sweeper_unit.py
+++ b/test/test_sweeper_unit.py
@@ -18,12 +18,21 @@ def _write_cfg(tmp_path, cfg_dict):
     return str(path)
 
 
+def _contains_key(obj, target):
+    """Recursively check whether `target` appears as a dict key anywhere in obj."""
+    if isinstance(obj, dict):
+        return target in obj or any(_contains_key(v, target) for v in obj.values())
+    if isinstance(obj, list):
+        return any(_contains_key(v, target) for v in obj)
+    return False
+
+
 def test_total_combinations_matches_fixture(sweeper):
     assert sweeper.total_combinations == 33
 
 
 def test_keys_set_contains_all_sweep_variables(sweeper):
-    assert sweeper.keys_set == {
+    assert sweeper._keys_set == {
         "algorithm",
         "param1",
         "param2",
@@ -33,6 +42,12 @@ def test_keys_set_contains_all_sweep_variables(sweeper):
         "param6",
         "simulator",
     }
+
+
+def test_config_dict_not_mutated_with_count_metadata(sweeper):
+    # Issue #39: combination counts live in class-owned state and are never
+    # written back into the user's parsed config.
+    assert not _contains_key(sweeper._config_dict, "num_combinations")
 
 
 @pytest.mark.parametrize(
@@ -197,53 +212,25 @@ def test_search_returns_empty_for_impossible_value(sweeper):
     assert sweeper.search({"param1": "DOES_NOT_EXIST"}, 1) == []
 
 
-def test_get_num_combinations_leaf_list():
-    assert Sweeper.get_num_combinations([1, 2, 3]) == 3
+# ----- _select index-to-value mapping (issue #22 guard) -----
+#
+# Scalar and dict-branch selection are covered end-to-end by the parse() tests
+# above (idx 24/28/32 exercise dict branches). What parse() never reaches is the
+# out-of-range guard, so it is pinned directly here.
 
 
-def test_get_num_combinations_with_dict_values():
-    values = [
-        {"num_combinations": 4},
-        {"num_combinations": 8},
-        "leaf",
-    ]
-    assert Sweeper.get_num_combinations(values) == 13
-
-
-def test_get_value_and_relative_idx_leaf_first():
-    value, rel = Sweeper.get_value_and_relative_idx(["a", "b", "c"], 0)
-    assert value == "a"
-    assert rel == 0
-
-
-def test_get_value_and_relative_idx_leaf_last():
-    value, rel = Sweeper.get_value_and_relative_idx(["a", "b", "c"], 2)
-    assert value == "c"
-    assert rel == 0
-
-
-def test_get_value_and_relative_idx_with_dict_value():
-    values = [
-        {"num_combinations": 3, "label": "first"},
-        {"num_combinations": 2, "label": "second"},
-    ]
-    value, rel = Sweeper.get_value_and_relative_idx(values, 3)
-    assert value["label"] == "second"
-    assert rel == 0
-
-
-def test_get_value_and_relative_idx_raises_when_idx_out_of_range():
-    # Pre-fix: the fallback returned a bare int, so callers' tuple unpack would
-    # explode with a misleading "cannot unpack non-iterable int" one frame up.
-    # Post-fix: raise IndexError at the source with a useful message (issue #22).
+def test_select_raises_when_idx_out_of_range(sweeper):
+    # Pre-fix the fallback returned a bare int, so the caller's tuple unpack
+    # exploded with a misleading "cannot unpack non-iterable int" one frame up.
+    # Post-fix raises IndexError at the source with a useful message (issue #22).
     with pytest.raises(IndexError, match="idx 99"):
-        Sweeper.get_value_and_relative_idx(["a", "b", "c"], 99)
+        sweeper._select(["a", "b", "c"], 99)
 
 
-def test_get_value_and_relative_idx_raises_at_exact_boundary():
-    # idx == len(values) is the smallest out-of-range value for a leaf list.
+def test_select_raises_at_exact_boundary(sweeper):
+    # idx == len(values) is the smallest out-of-range value for a scalar list.
     with pytest.raises(IndexError):
-        Sweeper.get_value_and_relative_idx(["a", "b", "c"], 3)
+        sweeper._select(["a", "b", "c"], 3)
 
 
 def test_minimal_single_value_sweep_runs_increment(tmp_path):


### PR DESCRIPTION
- Keep combination counts in a class-owned map keyed by id() instead of writing them back into the parsed config (#39)
- Privatize implementation helpers; public surface is now parse, search, total_combinations (#40)
- Rewrite search() to decide-then-append instead of append-then-retract (#41)

Closes #39, #40, #41.